### PR TITLE
fix: warning breaking customizer

### DIFF
--- a/wpmu-focus-point.php
+++ b/wpmu-focus-point.php
@@ -86,6 +86,7 @@ class WPMUFocusPoint
     function generateFocusPointField(string $axis, int $postId, string $value): array {
         return [
             'input' => 'html',
+            'label' => '',
             'html'  => sprintf(
                 '<input type="hidden" 
                         id="focus-point-%s-%d" 


### PR DESCRIPTION
missing label for field breaking customizer.
adding label for field resolves the issue.